### PR TITLE
Add Laravel Flake Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ nix flake init -t github:connsoisu/nix-config#go-shell
 nix flake init -t github:connsoisu/nix-config#remix-js-shell
 ```
 
+### Laravel dev shell
+
+> WARNING: It only provides the shell commands (php, composer, etc), not a way to build a package.
+> This template is only useful to avoid installing Laravel globally.
+
+```sh
+nix flake init -t github:connsoisu/nix-config#laravel-shell
+```
+
 Adding a package build is as simple as:
 ```nix 
 {

--- a/flake.nix
+++ b/flake.nix
@@ -105,6 +105,10 @@
         description = "An Elixir Phoenix Framework shell for developing with nix";
         path = ./templates/elixir-phoenix-shell;
       };
+      laravel-shell = {
+        description = "A Laravel shell for developing with nix";
+        path = ./templates/laravel-shell;
+      };
     };
 
     devShells = forAllSystems (system: let

--- a/templates/laravel-shell/.envrc
+++ b/templates/laravel-shell/.envrc
@@ -1,0 +1,1 @@
+use flake . --impure

--- a/templates/laravel-shell/.gitignore
+++ b/templates/laravel-shell/.gitignore
@@ -1,0 +1,2 @@
+.direnv
+result

--- a/templates/laravel-shell/flake.nix
+++ b/templates/laravel-shell/flake.nix
@@ -1,0 +1,64 @@
+{
+  description = "A development shell for Laravel";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+  outputs = inputs @ {nixpkgs, ...}: let
+    supportedSystems = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+    forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+  in {
+    devShells = forAllSystems (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+
+      scripts = {
+        dx = {
+          exec = ''$EDITOR "$REPO_ROOT"/flake.nix'';
+          description = "Edit flake.nix";
+        };
+        lx = {
+          exec = ''$EDITOR "$REPO_ROOT"/composer.json'';
+          description = "Edit composer.json";
+        };
+      };
+
+      scriptPackages =
+        pkgs.lib.mapAttrs
+        (
+          name: script:
+            pkgs.writeShellApplication {
+              inherit name;
+              text = script.exec;
+              runtimeInputs = script.deps or [];
+            }
+        )
+        scripts;
+    in {
+      default = pkgs.mkShell {
+        name = "dev";
+
+        # Available packages on https://search.nixos.org/packages
+        packages = with pkgs;
+          [
+            php
+            composer
+            nodejs
+            yarn
+            mysql
+            git
+          ]
+          ++ builtins.attrValues scriptPackages;
+
+        shellHook = ''
+          export REPO_ROOT=$(git rev-parse --show-toplevel)
+        '';
+      };
+    });
+  };
+}


### PR DESCRIPTION
Add Laravel Flake Template to the repository

* **flake.nix**
  - Add a new entry for the Laravel template under the `templates` section.
* **templates/laravel-shell/flake.nix**
  - Create a new `flake.nix` file for the Laravel development shell.
  - Include necessary Laravel dependencies and configurations.
* **templates/laravel-shell/.envrc**
  - Create a new `.envrc` file for the Laravel development shell.
  - Use the flake with `--impure` option.
* **templates/laravel-shell/.gitignore**
  - Create a new `.gitignore` file for the Laravel development shell.
  - Ignore `.direnv` and `result` directories.
* **README.md**
  - Add instructions for initializing a Laravel dev shell.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/conneroisu/dotfiles/pull/47?shareId=363377e8-1c31-4610-b308-16efacd82efc).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a Laravel development shell template for Nix flakes, providing a ready-to-use environment with PHP, Composer, Node.js, Yarn, MySQL, and Git.
  - Added convenient shell scripts for quick access to key project files.
- **Documentation**
  - Updated the README with instructions and details for using the new Laravel shell template.
- **Chores**
  - Added environment and gitignore configuration files to support the new template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->