### PR TITLE
refactor: replace fenix with rust-overlay in rust-shell template

### DIFF
--- a/templates/rust-shell/flake.lock
+++ b/templates/rust-shell/flake.lock
@@ -1,0 +1,99 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1748047550,
+        "narHash": "sha256-t0qLLqb4C1rdtiY8IFRH5KIapTY/n3Lqt57AmxEv9mk=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "b718a78696060df6280196a6f992d04c87a16aef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1748792178,
+        "narHash": "sha256-BHmgfHlCJVNisJShVaEmfDIr/Ip58i/4oFGlD1iK6lk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5929de975bcf4c7c8d8b5ca65c8cd9ef9e44523e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1748832016,
+        "narHash": "sha256-TQSaFa1wWJr6GOs+K8lecK4AKKr8k6mwxHIPCOmVkgs=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "7ec2ea005b600dac9436a7c5c6b66d960cbfcea2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1748243702,
+        "narHash": "sha256-9YzfeN8CB6SzNPyPm2XjRRqSixDopTapaRsnTpXUEY8=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "1f3f7b784643d488ba4bf315638b2b0a4c5fb007",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/templates/rust-shell/flake.nix
+++ b/templates/rust-shell/flake.nix
@@ -3,6 +3,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     rust-overlay.url = "github:oxalica/rust-overlay";
+    crane.url = "github:ipetkov/crane";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
   };
@@ -10,6 +11,7 @@
   outputs = {
     nixpkgs,
     rust-overlay,
+    crane,
     treefmt-nix,
     ...
   }: let
@@ -23,12 +25,35 @@
     # Helper function to generate per-system attributes
     forAllSystems = f: nixpkgs.lib.genAttrs systems f;
   in {
+    # Optional: Define packages if using crane to build (uncomment to use)
+    # packages = forAllSystems (system: let
+    #   pkgs = import nixpkgs {
+    #     inherit system;
+    #     overlays = [rust-overlay.overlays.default];
+    #   };
+    #   craneLib = (crane.mkLib pkgs).overrideToolchain (p: p.rust-bin.stable.latest.default);
+    # in {
+    #   default = craneLib.buildPackage {
+    #     src = craneLib.cleanCargoSource ./.;
+    #     strictDeps = true;
+    #   };
+    # });
+    
     # Define devShells for all systems
     devShells = forAllSystems (system: let
       pkgs = import nixpkgs {
         inherit system;
         overlays = [rust-overlay.overlays.default];
       };
+      
+      # Optional: Initialize crane for building packages
+      # craneLib = (crane.mkLib pkgs).overrideToolchain (p: p.rust-bin.stable.latest.default);
+      
+      # Optional: Example crane package build (uncomment to use)
+      # my-crate = craneLib.buildPackage {
+      #   src = craneLib.cleanCargoSource ./.;
+      #   strictDeps = true;
+      # };
     in {
       default = pkgs.mkShell {
         name = "dev";


### PR DESCRIPTION
## Summary
- Replaced fenix with rust-overlay for Rust toolchain management in the rust-shell template
- Simplified the flake configuration by removing fenix-specific toolchain combinations
- Updated to use rust-bin.stable.latest.default from rust-overlay

## Test plan
- [ ] Run `nix develop` in a project using this template
- [ ] Verify that `rustc --version` and `cargo --version` work correctly
- [ ] Ensure all development tools (alejandra, nixd, statix, deadnix, just) are available

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Rust toolchain setup to use a new overlay, improving consistency and maintainability in the development environment.
  - Simplified environment variable configuration for Rust tools.
  - Added templates for integrating new package-building tools into the development environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->