### PR TITLE
Improve prompt Exists error handling

### DIFF
--- a/modules/programs/par/cmd/add.go
+++ b/modules/programs/par/cmd/add.go
@@ -86,7 +86,11 @@ syntax highlighting and structure. Supports template prompts with variables.`,
 		}
 
 		// Check if prompt already exists
-		if manager.Exists(name) {
+		exists, err := manager.Exists(name)
+		if err != nil {
+			return fmt.Errorf("failed to check if prompt exists: %w", err)
+		}
+		if exists {
 			return fmt.Errorf("prompt '%s' already exists", name)
 		}
 

--- a/modules/programs/par/internal/prompts/manager.go
+++ b/modules/programs/par/internal/prompts/manager.go
@@ -125,12 +125,18 @@ func (m *Manager) Delete(name string) error {
 }
 
 // Exists checks if a prompt exists
-func (m *Manager) Exists(name string) bool {
+func (m *Manager) Exists(name string) (bool, error) {
 	filename := sanitizeFilename(name) + ".yaml"
 	filepath := filepath.Join(m.storageDir, filename)
 
 	_, err := os.Stat(filepath)
-	return !os.IsNotExist(err)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("failed to check prompt existence: %w", err)
 }
 
 // sanitizeFilename removes invalid characters from filenames


### PR DESCRIPTION
## Summary
- handle permission errors when checking prompt existence
- update add command to propagate existence check errors

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6843674b48288333bf1a4986171225d7