### PR TITLE
Add workers count validation to Pool

### DIFF
--- a/modules/programs/par/cmd/run.go
+++ b/modules/programs/par/cmd/run.go
@@ -148,7 +148,10 @@ simultaneously. This is the core functionality of par.`,
 		fmt.Printf("Executing %d jobs with %d workers...\n", len(jobList), jobs)
 
 		// Execute jobs
-		pool := executor.NewPool(jobs, cfg)
+		pool, err := executor.NewPool(jobs, cfg)
+		if err != nil {
+			return err
+		}
 		var jobResults []*executor.JobResult
 
 		if len(jobList) == 1 {

--- a/modules/programs/par/internal/executor/pool.go
+++ b/modules/programs/par/internal/executor/pool.go
@@ -22,7 +22,11 @@ type Pool struct {
 }
 
 // NewPool creates a new execution pool
-func NewPool(workers int, config *config.Config) *Pool {
+func NewPool(workers int, config *config.Config) (*Pool, error) {
+	if workers <= 0 {
+		return nil, fmt.Errorf("invalid worker count: %d", workers)
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &Pool{
@@ -33,7 +37,7 @@ func NewPool(workers int, config *config.Config) *Pool {
 		resultQueue: make(chan *JobResult, workers*2),
 		ctx:         ctx,
 		cancel:      cancel,
-	}
+	}, nil
 }
 
 // Execute executes a batch of jobs in parallel

--- a/spec/par.md
+++ b/spec/par.md
@@ -214,7 +214,10 @@ for i, worktree := range validWorktrees {
 
 ```go
 // Create worker pool
-pool := executor.NewPool(config.Jobs)
+pool, err := executor.NewPool(config.Jobs, config)
+if err != nil {
+    log.Fatal(err)
+}
 
 // Execute jobs
 results := pool.Execute(jobs)


### PR DESCRIPTION
## Summary
- validate `workers` argument in `NewPool`
- propagate error when pool creation fails
- update docs and usage accordingly

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6843672accbc8333a42e164f23d22370