### PR TITLE
Update flake.nix

### DIFF
--- a/templates/go-shell/flake.nix
+++ b/templates/go-shell/flake.nix
@@ -62,8 +62,8 @@
             go_1_24 # Go Tools
             air
             golangci-lint
+            gopls
             (buildWithSpecificGo revive)
-            (buildWithSpecificGo gopls)
             (buildWithSpecificGo golines)
             (buildWithSpecificGo golangci-lint-langserver)
             (buildWithSpecificGo gomarkdoc)


### PR DESCRIPTION
This pull request updates the `templates/go-shell/flake.nix` file to adjust how Go tools are included in the development environment. The most notable change is the direct inclusion of `gopls` instead of building it with a specific Go version.

Changes to Go tools management:

* [`templates/go-shell/flake.nix`](diffhunk://#diff-2964428219792585614251b930ccae9422e55dcb14348a18d534048dca70a1b8R65-L66): Added `gopls` directly to the list of tools and removed its inclusion via `buildWithSpecificGo`.