### PR TITLE
Add nix-env panic alias

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -45,6 +45,7 @@ alias wta='git worktree add'
 alias wt='git worktree'
 alias wtd='git worktree remove'
 alias k='kubectl'
+alias nix-env='echo "panic: nix-env is disabled (#61)" >&2 && false'
 
 
 # Load a few important annexes, without Turbo


### PR DESCRIPTION
## Summary
- disable accidental `nix-env` usage by aliasing it to print a panic message

## Testing
- `nix fmt` *(fails: `nix` not found)*
- `nix develop -c lint` *(fails: `nix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862775942c48333a103d3988715ac9f