### PR TITLE
Fix deprecated services.xserver.displayManager.gdm.enable option

### DIFF
--- a/modules/features/gnome.nix
+++ b/modules/features/gnome.nix
@@ -31,8 +31,8 @@ in
         };
         xserver = {
           enable = true;
-          displayManager.gdm.enable = true;
         };
+        displayManager.gdm.enable = true;
       };
     };
   }

--- a/modules/features/hyprland.nix
+++ b/modules/features/hyprland.nix
@@ -170,8 +170,8 @@ in
         };
         xserver = {
           enable = true;
-          displayManager.gdm.enable = true;
         };
+        displayManager.gdm.enable = true;
       };
 
       xdg = {


### PR DESCRIPTION
## Summary
- Fixed deprecated `services.xserver.displayManager.gdm.enable` option in hyprland.nix and gnome.nix
- Updated to use the new `services.displayManager.gdm.enable` path instead

## Test plan
- [x] Verified nix flake check passes without deprecation warnings
- [x] Both hyprland and gnome modules now use the correct option path

🤖 Generated with [Claude Code](https://claude.ai/code)