### PR TITLE
fix crush version and add man to zshell module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,7 @@ nix develop -c lint # Run quality checks
     zen-browser.inputs.nixpkgs.follows = "nixpkgs";
     proton-authenticator.url = "github:conneroisu/proton-authenticator-flake?tag=v1.0.1";
     proton-authenticator.inputs.nixpkgs.follows = "nixpkgs";
-    crush.url = "github:conneroisu/crush-flake";
+    crush.url = "github:conneroisu/crush-flake?tag=v0.4.0";
     crush.inputs.nixpkgs.follows = "nixpkgs";
 
     ashell.url = "github:MalpenZibo/ashell?ref=1b57fbcba87f48ca1075dca48021ec55586caeea";

--- a/modules/features/zshell.nix
+++ b/modules/features/zshell.nix
@@ -89,6 +89,7 @@ designed to be enabled by higher-level feature modules like `engineer.nix`.
     carapace
     uv
     git
+    man
   ];
 in
   delib.module {


### PR DESCRIPTION
This pull request makes minor improvements to the project's dependencies and shell environment. The most important changes are:

Dependency updates:
* Updated the `crush` dependency in `flake.nix` to use the tagged release `v0.4.0` instead of the latest commit, which helps ensure reproducibility and stability.

Shell environment enhancements:
* Added the `man` package to the default set of packages in the `zshell.nix` feature module, providing users with access to manual pages in their shell environment.