### PR TITLE
set the default haiku model to glm4.6

### DIFF
--- a/modules/programs/zlaude/default.nix
+++ b/modules/programs/zlaude/default.nix
@@ -16,7 +16,7 @@ Z.AI Claude
       "SC2155"
     ];
     runtimeEnv = {
-      "ANTHROPIC_DEFAULT_HAIKU_MODEL" = "glm-4.5-air";
+      "ANTHROPIC_DEFAULT_HAIKU_MODEL" = "glm-4.6";
       "ANTHROPIC_DEFAULT_SONNET_MODEL" = "glm-4.6";
       "ANTHROPIC_DEFAULT_OPUS_MODEL" = "glm-4.6";
     };


### PR DESCRIPTION
This pull request updates the default Anthropic model version used for the Haiku model in the `Z.AI Claude` program configuration to ensure consistency with the Sonnet and Opus models.

Model version updates:

* Updated the `ANTHROPIC_DEFAULT_HAIKU_MODEL` environment variable from `glm-4.5-air` to `glm-4.6` in `modules/programs/zlaude/default.nix`, aligning it with the default versions for Sonnet and Opus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Anthropic Haiku model from glm-4.5-air to glm-4.6, aligning with Sonnet and Opus models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->