### PR TITLE
Update deprecated NVIDIA Docker virtualization setting

### DIFF
--- a/modules/features/nvidia.nix
+++ b/modules/features/nvidia.nix
@@ -89,8 +89,8 @@ in
 
     nixos.ifEnabled = {myconfig, ...}: {
       # Load nvidia driver for Xorg and Wayland
-      virtualisation.docker.enableNvidia = true;
       hardware = {
+        nvidia-container-toolkit.enable = true;
         nvidia = {
           open = false;
           prime = {
@@ -113,7 +113,6 @@ in
           enable32Bit = true;
         };
       };
-      # hardware.nvidia-container-toolkit.enable = true;
 
       services = {
         displayManager = {


### PR DESCRIPTION
…are.nvidia-container-toolkit.enable

The virtualisation.docker.enableNvidia option is deprecated in favor of hardware.nvidia-container-toolkit.enable. This change updates the nvidia feature module to use the new option, eliminating the deprecation warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated NVIDIA container toolkit configuration to use dedicated hardware support module, replacing the previous Docker-based integration approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->