### PR TITLE
Rename pkgs.system to pk

### DIFF
--- a/modules/features/engineer.nix
+++ b/modules/features/engineer.nix
@@ -143,15 +143,15 @@ in
             zed-editor
           ]
           ++ [
-            inputs.kiro-flake.packages."${pkgs.system}".default
-            inputs.conclaude.packages."${pkgs.system}".default
-            inputs.nix-ai-tools.packages."${pkgs.system}".crush
-            inputs.nordvpn.packages."${pkgs.system}".default
-            inputs.zen-browser.packages."${pkgs.system}".default
-            inputs.blink.packages."${pkgs.system}".default
-            inputs.blink.packages."${pkgs.system}".blink-fuzzy-lib
-            inputs.nix-auth.packages."${pkgs.system}".default
-            inputs.nix-version-search.packages."${pkgs.system}".default
+            inputs.kiro-flake.packages."${pkgs.stdenv.hostPlatform.system}".default
+            inputs.conclaude.packages."${pkgs.stdenv.hostPlatform.system}".default
+            inputs.nix-ai-tools.packages."${pkgs.stdenv.hostPlatform.system}".crush
+            inputs.nordvpn.packages."${pkgs.stdenv.hostPlatform.system}".default
+            inputs.zen-browser.packages."${pkgs.stdenv.hostPlatform.system}".default
+            inputs.blink.packages."${pkgs.stdenv.hostPlatform.system}".default
+            inputs.blink.packages."${pkgs.stdenv.hostPlatform.system}".blink-fuzzy-lib
+            inputs.nix-auth.packages."${pkgs.stdenv.hostPlatform.system}".default
+            inputs.nix-version-search.packages."${pkgs.stdenv.hostPlatform.system}".default
           ];
         variables = {
           EDITOR = "nvim";
@@ -233,9 +233,9 @@ in
           lua-language-server
 
           # Nix tools
-          inputs.nix-auth.packages."${pkgs.system}".default
-          inputs.nix-ai-tools.packages."${pkgs.system}".crush
-          inputs.conclaude.packages."${pkgs.system}".default
+          inputs.nix-auth.packages."${pkgs.stdenv.hostPlatform.system}".default
+          inputs.nix-ai-tools.packages."${pkgs.stdenv.hostPlatform.system}".crush
+          inputs.conclaude.packages."${pkgs.stdenv.hostPlatform.system}".default
         ];
         variables = {
           EDITOR = "nvim";

--- a/modules/features/hyprland.nix
+++ b/modules/features/hyprland.nix
@@ -95,8 +95,8 @@ in
       environment = {
         systemPackages =
           [
-            inputs.ghostty.packages."${pkgs.system}".default
-            inputs.hyprland.packages."${pkgs.system}".default
+            inputs.ghostty.packages."${pkgs.stdenv.hostPlatform.system}".default
+            inputs.hyprland.packages."${pkgs.stdenv.hostPlatform.system}".default
             (pkgs.rofi.override {
               plugins = [
                 pkgs.rofi-rbw
@@ -149,8 +149,8 @@ in
         dconf.enable = true;
         ydotool.enable = true;
         hyprland = {
-          package = inputs.hyprland.packages.${pkgs.system}.default;
-          portalPackage = inputs.hyprland.packages.${pkgs.system}.xdg-desktop-portal-hyprland;
+          package = inputs.hyprland.packages.${pkgs.stdenv.hostPlatform.system}.default;
+          portalPackage = inputs.hyprland.packages.${pkgs.stdenv.hostPlatform.system}.xdg-desktop-portal-hyprland;
           enable = true;
           withUWSM = true;
           xwayland.enable = true;
@@ -187,7 +187,7 @@ in
         portal = {
           enable = true;
           wlr.enable = true;
-          extraPortals = [inputs.hyprland.packages.${pkgs.system}.xdg-desktop-portal-hyprland];
+          extraPortals = [inputs.hyprland.packages.${pkgs.stdenv.hostPlatform.system}.xdg-desktop-portal-hyprland];
 
           config.hyprland = {
             default = [

--- a/modules/programs/proton-x/default.nix
+++ b/modules/programs/proton-x/default.nix
@@ -17,7 +17,7 @@ in
         pkgs.protonmail-desktop
         pkgs.proton-pass
 
-        inputs.proton-authenticator.packages."${pkgs.system}".default
+        inputs.proton-authenticator.packages."${pkgs.stdenv.hostPlatform.system}".default
       ];
     };
     darwin.ifEnabled = {


### PR DESCRIPTION
Update all references from the deprecated pkgs.system to the recommended pkgs.stdenv.hostPlatform.system across feature modules and program definitions. This follows NixOS best practices for platform detection.

Files changed:
- modules/features/hyprland.nix (5 occurrences)
- modules/features/engineer.nix (10 occurrences)
- modules/programs/proton-x/default.nix (1 occurrence)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed package selection mechanism to correctly identify and use your system's platform across system tools, desktop environment, and authentication utilities, ensuring proper compatibility and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->